### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "pulsestorm/wp-static-html-output-plugin",
-	"type": "command",
+	"type": "wp-cli-package",
 	"description": "Unofficial WP-CLI wrapper for the WP Static HTML Output Plugin ",
 	"keywords": ["wp-cli", "static", "wordpress", "html", ""],
 	"homepage": "https://github.com/astorm/wp-static-html-output-plugin",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
